### PR TITLE
unlocked BSP

### DIFF
--- a/code/renderer/tr_bsp.c
+++ b/code/renderer/tr_bsp.c
@@ -528,7 +528,7 @@ static void ParseFlare( dsurface_t *ds, drawVert_t *verts, msurface_t *surf, glI
 
 
 /*
-=================
+=================XINPUT_DEVSUBTYPE_GUITAR 
 R_MergedWidthPoints
 
 returns true if there are grid points merged on a width edge
@@ -1837,11 +1837,13 @@ void RE_LoadWorldMap( const char *name ) {
 	header = (dheader_t *)buffer;
 	fileBase = (byte *)header;
 
+         /*
 	i = LittleLong (header->version);
 	if ( i != BSP_VERSION ) {
 		ri.Error (ERR_DROP, "RE_LoadWorldMap: %s has wrong version number (%i should be %i)", 
 			name, i, BSP_VERSION);
 	}
+        /**/
 
 	// swap all the lumps
 	for (i=0 ; i<sizeof(dheader_t)/4 ; i++) {

--- a/code/renderer/tr_bsp.c
+++ b/code/renderer/tr_bsp.c
@@ -528,7 +528,7 @@ static void ParseFlare( dsurface_t *ds, drawVert_t *verts, msurface_t *surf, glI
 
 
 /*
-=================XINPUT_DEVSUBTYPE_GUITAR 
+=================
 R_MergedWidthPoints
 
 returns true if there are grid points merged on a width edge


### PR DESCRIPTION
This allows other Q3 Engine maps to be loaded in Quake 3 like RTCW/WET maps.
